### PR TITLE
Fix multiline Label widget to incorrectly display message with hyperlink

### DIFF
--- a/pytermgui/markup/parsing.py
+++ b/pytermgui/markup/parsing.py
@@ -719,6 +719,9 @@ def parse_tokens(  # pylint: disable=too-many-branches, too-many-locals, too-man
                     token.value, "has nothing to target", get_full()
                 )
 
+            if token.value == "/~":
+                continue
+
         if Token.is_color(token) and token.color.background:
             background = token.color
 

--- a/pytermgui/markup/style_maps.py
+++ b/pytermgui/markup/style_maps.py
@@ -17,7 +17,6 @@ REVERSE_STYLES = {value: key for key, value in STYLES.items()}
 
 CLEARERS = {
     "/": "0",
-    "/~": "8;;\x1b\\",
     "/bold": "22",
     "/dim": "22",
     "/italic": "23",

--- a/pytermgui/markup/style_maps.py
+++ b/pytermgui/markup/style_maps.py
@@ -17,6 +17,7 @@ REVERSE_STYLES = {value: key for key, value in STYLES.items()}
 
 CLEARERS = {
     "/": "0",
+    "/~": "8;;\x1b\\",
     "/bold": "22",
     "/dim": "22",
     "/italic": "23",

--- a/pytermgui/regex.py
+++ b/pytermgui/regex.py
@@ -3,7 +3,7 @@
 import re
 from functools import lru_cache
 
-RE_LINK = re.compile(r"(?:\x1b\]8;;([^\\]*)\x1b\\([^\\]*)\x1b\]8;;\x1b\\)")
+RE_LINK = re.compile(r"(?:\x1b\]8;;([^\\]*)\x1b\\([^\\]*?)\x1b\]8;;\x1b\\)")
 RE_ANSI_NEW = re.compile(rf"(\x1b\[(.*?)[mH])|{RE_LINK.pattern}|(\x1b_G(.*?)\x1b\\)")
 RE_ANSI = re.compile(r"(?:\x1b\[(.*?)[mH])|(?:\x1b\](.*?)\x1b\\)|(?:\x1b_G(.*?)\x1b\\)")
 RE_MACRO = re.compile(r"(![a-z0-9_\-]+)(?:\(([\w\/\.?\-=:]+)\))?")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -98,6 +98,13 @@ class TestParser:
         markup = tim.get_markup(ansi)
         assert base == markup
 
+    def test_mutiline_markup(self):
+        base = "[141 @61 bold]Hello[/]\nWhat a beautifull day to look a this [~https://example.com]website[/~] !\nOh and this [~https://example.com]website also[/~]\nHave a nice day !"
+        opti_base = "[141 @61 bold]Hello[/]\nWhat a beautifull day to look a this [~https://example.com]website[/~] !\nOh and this [~https://example.com]website also[/~]\nHave a nice day ![/]"
+        ansi = tim.parse(base)
+        markup = tim.get_markup(ansi)
+        assert opti_base == markup
+
     def test_parse(self):
         assert (
             tim.parse("[141 @61 bold !upper]Hello")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,10 +6,18 @@ from itertools import zip_longest
 
 import pytest
 
-from pytermgui import StyledText, pretty, tim, tokenize_ansi, tokens_to_markup
+from pytermgui import (
+    StyledText,
+    pretty,
+    tim,
+    tokenize_ansi,
+    tokens_to_markup,
+    tokenize_markup,
+)
 from pytermgui.colors import Color, str_to_color
 from pytermgui.markup import StyledText, Token
 from pytermgui.markup import tokens as tkns
+from pytermgui.markup.parsing import parse_tokens
 from pytermgui.markup.style_maps import CLEARERS, STYLES
 
 
@@ -101,6 +109,13 @@ class TestParser:
     def test_mutiline_markup(self):
         base = "[141 @61 bold]Hello[/]\nWhat a beautifull day to look a this [~https://example.com]website[/~] !\nOh and this [~https://example.com]website also[/~]\nHave a nice day !"
         opti_base = "[141 @61 bold]Hello[/]\nWhat a beautifull day to look a this [~https://example.com]website[/~] !\nOh and this [~https://example.com]website also[/~]\nHave a nice day ![/]"
+
+        tokens = tokenize_markup(base)
+        ansi = parse_tokens(list(tokens))
+        tokens2 = tokenize_ansi(ansi)
+        markup = tokens_to_markup(list(tokens2))
+        assert opti_base == markup
+
         ansi = tim.parse(base)
         markup = tim.get_markup(ansi)
         assert opti_base == markup


### PR DESCRIPTION
This is a fix for #107.

All the test are passing but mypy is angry about file I did not modify, I don't know if this is an issue.

Also pylint wanted to change some yaml (maybe the actual configuration is not enough ?) and black is complaining about files in the `docs` folder (that do not seems to be python)

I've just one small interrogation, In case of multiline string, it's complicated to enact the hyperlink specification of TIM in the case you're omitting the last `[/~]`, should `\n` be considered as such ? Or do you allow multiline hyperlink ? In this MR, the behaviour is:
  - If there is no ending `[/~]` one is appended to the string.