### PR TITLE
Implement alt/ctrl+backspace to remove whole words

### DIFF
--- a/pytermgui/input.py
+++ b/pytermgui/input.py
@@ -369,6 +369,8 @@ except ImportError as import_error:
         "ALT_SHIFT_DOWN": "\x1b[1;4B",
         "ALT_SHIFT_RIGHT": "\x1b[1;4C",
         "ALT_SHIFT_LEFT": "\x1b[1;4D",
+        "ALT_BACKSPACE": "\x08",
+        "CTRL_BACKSPACE": "\x1b\x7f",
         "CTRL_UP": "\x1b[1;5A",
         "CTRL_DOWN": "\x1b[1;5B",
         "CTRL_RIGHT": "\x1b[1;5C",

--- a/pytermgui/widgets/input_field.py
+++ b/pytermgui/widgets/input_field.py
@@ -239,7 +239,7 @@ class InputField(Widget):  # pylint: disable=too-many-instance-attributes
             return True
 
         if action == 'word_remove':
-            row, _ = self.cursor
+            row, col = self.cursor
             if len(self._lines) > row:
                 # Consistent with unix shell behaviour:
                 # * Always delete first char, then remove any non-punctuation
@@ -247,7 +247,7 @@ class InputField(Widget):  # pylint: disable=too-many-instance-attributes
                 # * Python repl: until change in letter+digit & punctionation
                 # * Unix shells: only removes letter+digit
                 word_chars = string.ascii_letters + string.digits
-                line = self._lines[row][:-1]
+                line = self._lines[row][:col-1]
                 strip_line = line.rstrip(word_chars)
                 self.delete_back(len(line) - len(strip_line) + 1)
             else:

--- a/pytermgui/widgets/input_field.py
+++ b/pytermgui/widgets/input_field.py
@@ -57,6 +57,7 @@ class InputField(Widget):  # pylint: disable=too-many-instance-attributes
         "select_right": {keys.SHIFT_RIGHT},
         "select_up": {keys.SHIFT_UP},
         "select_down": {keys.SHIFT_DOWN},
+        "word_remove": {keys.ALT_BACKSPACE, keys.CTRL_BACKSPACE},
     }
 
     parent_align = HorizontalAlignment.LEFT
@@ -236,6 +237,21 @@ class InputField(Widget):  # pylint: disable=too-many-instance-attributes
                 self.update_selection(-1)
 
             return True
+
+        if action == 'word_remove':
+            row, _ = self.cursor
+            if len(self._lines) > row:
+                # Consistent with unix shell behaviour:
+                # * Always delete first char, then remove any non-punctuation
+                # Note that the exact behaviour isn't standardized:
+                # * Python repl: until change in letter+digit & punctionation
+                # * Unix shells: only removes letter+digit
+                word_chars = string.ascii_letters + string.digits
+                line = self._lines[row][:-1]
+                strip_line = line.rstrip(word_chars)
+                self.delete_back(len(line) - len(strip_line) + 1)
+            else:
+                self.delete_back(1)
 
         return False
 


### PR DESCRIPTION
I was missing this feature so I added it. 

Already tested both Alt+Backspace & Ctrl+Backspace on Linux, I believ Ctrl+Backspace is also standard in windows but don't have any reference for the keycode so it's not implemented.