### PR TITLE
Implement word move (Ctrl/Alt+<L>/<R>) & Home/End move

### DIFF
--- a/pytermgui/input.py
+++ b/pytermgui/input.py
@@ -376,6 +376,8 @@ except ImportError as import_error:
         "CTRL_RIGHT": "\x1b[1;5C",
         "CTRL_LEFT": "\x1b[1;5D",
         "BACKSPACE": "\x7f",
+        "END": "\x1b[H",
+        "HOME": "\x1b[F",
         "INSERT": "\x1b[2~",
         "DELETE": "\x1b[3~",
         "BACKTAB": "\x1b[Z",


### PR DESCRIPTION
Hey there,
This is a follow up https://github.com/bczsalba/pytermgui/pull/109 allowing word move that is standard in most shells as well as Home/End movement within InputFields. Similar to #109 I only have keycodes for posix but should be easy to add if needed.

