### PR TITLE
Fix input errors when alert is open

### DIFF
--- a/pytermgui/input.py
+++ b/pytermgui/input.py
@@ -154,7 +154,7 @@ class _GetchWindows:
         """
 
         if isinstance(string, bytes):
-            return string.decode("utf-8")
+            return string.decode("utf-8", "ignore")
 
         return string
 


### PR DESCRIPTION
Ignore the 0xe0 byte error when alert is open, and pressing arrow key twice. (Normally causing error & exit)

```
PyTermGUI version 7.3.0

System details:
    Python version: 3.10.0
    $TERM:          None
    $COLORTERM:     None
    Color support:  ColorSystem.STANDARD
    OS Platform:    Windows-10-10.0.19045-SP0
```

https://user-images.githubusercontent.com/63415260/221367481-27f6a8dc-188a-453d-80ea-6bdb9bab812c.mp4

