### PR TITLE
Remove redraw flashing

### DIFF
--- a/pytermgui/term.py
+++ b/pytermgui/term.py
@@ -576,6 +576,19 @@ class Terminal:  # pylint: disable=too-many-instance-attributes
 
         self._stream.write("\x1b[2J")
 
+    def home(self) -> None:
+        """Truncates terminal's stream and moves cursor to home (0, 0)."""
+
+        try:
+            self._stream.truncate(0)
+
+        except OSError as error:
+            if error.errno != errno.EINVAL and os.name != "nt":
+                raise
+
+        self._stream.write("\x1b[H")
+
+
     def print(
         self,
         *items,

--- a/pytermgui/window_manager/compositor.py
+++ b/pytermgui/window_manager/compositor.py
@@ -230,7 +230,7 @@ class Compositor:
 
         self._should_redraw = True
 
-    def draw(self, force: bool = False) -> None:
+    def draw(self, force: bool = False, full: bool = False) -> None:
         """Writes composited screen to the terminal.
 
         At the moment this uses full-screen rewrites. There is a compositing
@@ -239,6 +239,8 @@ class Compositor:
         Args:
             force: When set, new composited lines will not be checked against the
                 previous ones, and everything will be redrawn.
+            full: When set, the terminal stream will be cleared instead of just the cursor
+                being moved to home.
         """
 
         # if self._should_redraw or force:
@@ -255,7 +257,11 @@ class Compositor:
         if not force and self._previous == lines:
             return
 
-        self.terminal.clear_stream()
+        if full:
+            self.terminal.clear_stream()
+        else:
+            self.terminal.home()
+
         with self.terminal.frame() as frame:
             frame_write = frame.write
 
@@ -264,10 +270,10 @@ class Compositor:
 
         self._previous = lines
 
-    def redraw(self) -> None:
+    def redraw(self, full: bool = False) -> None:
         """Force-redraws the buffer."""
 
-        self.draw(force=True)
+        self.draw(force=True, full=full)
 
     def capture(self, title: str, filename: str | None = None) -> None:
         """Captures the most-recently drawn buffer as `filename`.

--- a/pytermgui/window_manager/manager.py
+++ b/pytermgui/window_manager/manager.py
@@ -171,7 +171,7 @@ class WindowManager(Widget):  # pylint: disable=too-many-instance-attributes
             window.pos = (newx, newy)
 
         self.layout.apply()
-        self.compositor.redraw()
+        self.compositor.redraw(full=True)
 
     def run(self, mouse_events: list[str] | None = None) -> None:
         """Starts the WindowManager.


### PR DESCRIPTION
All instances of redrawing will now call \x1b[H to go to home position and then draw over all characters on the screen. This removed screen flickering for many if not most of terminal emulators. When a full redraw is needed, when the terminal resizes, the redraw is set to full and will fully clear the screen instead of going to home.