### PR TITLE
Added AUR repo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 > Python TUI framework with mouse support, modular widget system, customizable and rapid terminal markup language and more!
 
 ```bash
+# PIP
 pip3 install pytermgui
+
+# Arch Linux (AUR)
+yay -S python-pytermgui-git
 ```
 
 <p align=center>


### PR DESCRIPTION
I have created an AUR package. Because on Arch Linux the use of Pip is only possible in a virtual environment. If you try to use pip system/user wide, pip will interfere and expects the package to be installed via Pacman (the package manager of Arch Linux)

Here is the link: https://aur.archlinux.org/packages/python-pytermgui-git