### PR TITLE
Fixed character loss during rapid Unix input

### DIFF
--- a/pytermgui/input.py
+++ b/pytermgui/input.py
@@ -134,7 +134,7 @@ class _GetchUnix:
 
         descriptor = sys.stdin.fileno()
         old_settings = termios.tcgetattr(descriptor)
-        tty.setcbreak(descriptor)
+        tty.setcbreak(descriptor, termios.TCSANOW)
 
         try:
             yield self._read(1)


### PR DESCRIPTION
Addresses an issue where the class _GetchUnix failed to capture all characters
when input was provided rapidly in in the terminal.
For example when using a HID-Device (QR) code scanner. That is able to create
fast keyboard inputs.
This ensures that fast inputs are now processed correctly without data loss.