### PR TITLE
Fix focus_next reverse wrapping

### DIFF
--- a/pytermgui/window_manager/manager.py
+++ b/pytermgui/window_manager/manager.py
@@ -309,10 +309,7 @@ class WindowManager(Widget):  # pylint: disable=too-many-instance-attributes
             step: The direction to step through windows. +1 for next, -1 for previous.
         """
 
-        self._focus_index += step
-
-        if self._focus_index >= len(self._windows):
-            self._focus_index = 0
+        self._focus_index = (self._focus_index + step) % len(self._windows)
 
         if self.focused is not None:
             self.focused.blur()


### PR DESCRIPTION
When using focus_next with a negative step it would cause an exception instead of properly wrapping around - using modulo makes it work correctly in either direction