### PR TITLE
BugFix "flickering"

### DIFF
--- a/pytermgui/ansi_interface.py
+++ b/pytermgui/ansi_interface.py
@@ -116,7 +116,7 @@ def clear(what: str = "screen") -> None:
     commands = {
         "eos": "\x1b[0J",
         "bos": "\x1b[1J",
-        "screen": "\x1b[2J",
+        "screen": "\x1b[H\x1b[2J",
         "eol": "\x1b[0K",
         "bol": "\x1b[1K",
         "line": "\x1b[2K",

--- a/pytermgui/term.py
+++ b/pytermgui/term.py
@@ -358,7 +358,7 @@ class Terminal:  # pylint: disable=too-many-instance-attributes
         self._call_listener(self.RESIZE, self.size)
 
         # Wipe the screen in case anything got messed up
-        self.write("\x1b[2J")
+        self.write("\x1b[H\x1b[2J")
 
     @property
     def width(self) -> int:
@@ -454,15 +454,15 @@ class Terminal:  # pylint: disable=too-many-instance-attributes
         buffer = StringIO()
 
         try:
-            with self.no_record():
-                self.write("\x1b[?2026h")
+            # Write directly to stream to avoid write()'s auto-clear behavior
+            self._stream.write("\x1b[?2026h")
             yield buffer
 
         finally:
-            self.write(buffer.getvalue())
-            with self.no_record():
-                self.write("\x1b[?2026l")
-            self.flush()
+            # Write buffer directly to stream - bypasses write()'s \x1b[2J detection
+            self._stream.write(buffer.getvalue())
+            self._stream.write("\x1b[?2026l")
+            self._stream.flush()
 
     @staticmethod
     def isatty() -> bool:
@@ -532,6 +532,7 @@ class Terminal:  # pylint: disable=too-many-instance-attributes
 
             return sliced
 
+        # Truncate pending buffer on clear (may help on Windows)
         if "\x1b[2J" in data:
             self.clear_stream()
 
@@ -565,7 +566,11 @@ class Terminal:  # pylint: disable=too-many-instance-attributes
             self._stream.flush()
 
     def clear_stream(self) -> None:
-        """Clears (truncates) the terminal's stream."""
+        """Clears the terminal screen.
+
+        Attempts to truncate any buffered stream data (may work on Windows),
+        then moves cursor to home position and clears the entire screen.
+        """
 
         try:
             self._stream.truncate(0)
@@ -574,7 +579,7 @@ class Terminal:  # pylint: disable=too-many-instance-attributes
             if error.errno != errno.EINVAL and os.name != "nt":
                 raise
 
-        self._stream.write("\x1b[2J")
+        self._stream.write("\x1b[H\x1b[2J")
 
     def print(
         self,

--- a/pytermgui/window_manager/compositor.py
+++ b/pytermgui/window_manager/compositor.py
@@ -255,7 +255,6 @@ class Compositor:
         if not force and self._previous == lines:
             return
 
-        self.terminal.clear_stream()
         with self.terminal.frame() as frame:
             frame_write = frame.write
 


### PR DESCRIPTION
Closes #81.

**Problem**: ``frame()`` implements DEC 2026 synchronized output but the screen still flickers badly. Two issues prevented it from working:

1. The compositor calls clear_stream() outside the sync frame
2. Even when ``\x1b[2J`` is written to the frame buffer, the write() method detects it during flush and calls ``clear_stream()`` directly to the stream, bypassing synchronization

**Solution**: ``frame()`` now writes directly to ``self._stream``, bypassing ``self.write()`` and its ``\x1b[2J`` check. The clear is removed from each frame, as each line uses explicit cursor positioning to "draw over" previous frame, there is no need to "clean" it first by my judgement, please review! HOME (``\x1b[H``) is also added before clear sequences for deterministic cursor positioning.

Terminals without DEC 2026 support (like PuTTY) benefit most from removing the clear sequence from each frame.

https://github.com/user-attachments/assets/0720209f-965c-4d30-bc1c-0554739d9ea5

https://github.com/user-attachments/assets/88dd0916-c718-484f-a45b-a030631ed51a

Light flickering was noticeable on terminals with 2026 support and are also entirely flicker-free after this change.