### PR TITLE
Bugfix word-wrapping with many kinds of complex Unicode

### DIFF
--- a/examples/wcwidth_demo.py
+++ b/examples/wcwidth_demo.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Run: python examples/wcwidth_demo.py
+
+Demonstrates break_line() issues with wide characters and grapheme clusters.
+"""
+import pytermgui as ptg
+
+CJK = "中文字符"
+FAMILY = "\U0001F468\u200D\U0001F469\u200D\U0001F467"
+FLAG = "\U0001F1E8\U0001F1E6"  # Canada
+
+# Additional grapheme examples from wcwidth tests
+WAVE_SKIN = "\U0001F44B\U0001F3FB"  # Waving hand + skin tone modifier
+HEART_VS16 = "\u2764\uFE0F"  # Heart + variation selector-16
+CAFE = "cafe\u0301"  # café with combining acute accent
+WOMAN_TECH = "\U0001f469\U0001f3fb\u200d\U0001f4bb"  # Woman technologist (ZWJ)
+KISS = "\U0001F9D1\U0001F3FB\u200d\u2764\uFE0F\u200d\U0001F48B\u200d\U0001F9D1\U0001F3FD"  # Kiss
+
+# ANSI escape codes for color testing
+RST = "\x1b[0m"
+BOLD = "\x1b[1m"
+ITALIC = "\x1b[3m"
+RED = "\x1b[31m"
+GREEN = "\x1b[32m"
+ORANGE_256 = "\x1b[38;5;208m"
+PURPLE_256 = "\x1b[38;5;129m"
+CYAN_RGB = "\x1b[38;2;0;255;255m"
+PINK_RGB = "\x1b[38;2;255;105;180m"
+
+# Big word with 24-bit RGB gradient
+CHOOCHOO = (
+    "\x1b[38;2;255;0;0mc"
+    "\x1b[38;2;255;127;0mh"
+    "\x1b[38;2;255;255;0mo"
+    "\x1b[38;2;0;255;0mo"
+    "\x1b[38;2;0;255;127mc"
+    "\x1b[38;2;0;255;255mh"
+    "\x1b[38;2;0;127;255mo"
+    "\x1b[38;2;0;0;255mo"
+    "\x1b[38;2;127;0;255mp"
+    "\x1b[38;2;255;0;255mo"
+    "\x1b[38;2;255;0;127mn"
+    "\x1b[38;2;255;0;0my"
+    "\x1b[38;2;255;127;0me"
+    "\x1b[38;2;255;255;0mx"
+    "\x1b[38;2;0;255;0mp"
+    "\x1b[38;2;0;255;127mr"
+    "\x1b[38;2;0;255;255me"
+    "\x1b[38;2;0;127;255ms"
+    "\x1b[38;2;0;0;255ms"
+    "\x1b[0m"
+)
+
+ptg.WindowManager.autorun = False
+
+# Track adjustable containers and current width
+current_width = 19
+column_width = 25
+adjustable_containers = []
+column_containers = []
+main_window = None
+
+
+def adjust_width(delta):
+    """Adjust width of all tracked containers."""
+    global current_width, column_width, main_window
+    new_width = max(6, min(30, current_width + delta))
+    if new_width != current_width:
+        current_width = new_width
+        column_width = column_width + delta
+        for container in adjustable_containers:
+            container.static_width = current_width
+        for column in column_containers:
+            column.static_width = column_width
+        if main_window is not None:
+            main_window.width = main_window.width + delta * 4
+        width_label.value = f"[dim]Width: {current_width}  |  ←/→ adjust  |  Ctrl+C exit[/]"
+
+
+with ptg.WindowManager() as manager:
+    manager.mouse_enabled = False
+
+    # Bind arrow keys for width adjustment
+    manager.bind(ptg.keys.LEFT, lambda *_: adjust_width(-1), "Decrease width")
+    manager.bind(ptg.keys.RIGHT, lambda *_: adjust_width(1), "Increase width")
+
+    # Create containers and track the adjustable ones
+    sgr_box = ptg.Container(ptg.Label(f"{BOLD}bold{RST} {ITALIC}italic{RST}"),
+                            static_width=current_width)
+    colors_box = ptg.Container(ptg.Label(f"{RED}red{RST} {GREEN}green{RST}"),
+                               static_width=current_width)
+    c256_box = ptg.Container(ptg.Label(f"{ORANGE_256}orange{RST} {PURPLE_256}purple{RST}"),
+                             static_width=current_width)
+    rgb_box = ptg.Container(ptg.Label(f"{CYAN_RGB}cyan{RST} {PINK_RGB}pink{RST}"),
+                            static_width=current_width)
+
+    wrap_box = ptg.Container(ptg.Label("The quick-brown-fox"), static_width=current_width)
+    cjk_box = ptg.Container(ptg.Label(CJK + CJK), static_width=current_width)
+    family_box = ptg.Container(ptg.Label(f"Hi{FAMILY}!"), static_width=current_width)
+    flag_box = ptg.Container(ptg.Label(f"{FLAG}Canada"), static_width=current_width)
+
+    combine_box = ptg.Container(ptg.Label(f"A {CAFE}!"), static_width=current_width)
+    skin_box = ptg.Container(ptg.Label(f"Hi{WAVE_SKIN}!"), static_width=current_width)
+    heart_box = ptg.Container(ptg.Label(f"I{HEART_VS16}U"), static_width=current_width)
+    tech_box = ptg.Container(ptg.Label(f"{WOMAN_TECH}codes"), static_width=current_width)
+    lorem_box = ptg.Container(ptg.Label("Lorem ipsum dolor sit"), static_width=current_width)
+    choochoo_box = ptg.Container(ptg.Label(CHOOCHOO), static_width=current_width)
+
+    adjustable_containers = [
+        sgr_box, colors_box, c256_box, rgb_box,
+        wrap_box, cjk_box, family_box, flag_box,
+        combine_box, skin_box, heart_box, tech_box,
+        lorem_box, choochoo_box,
+    ]
+
+    left = ptg.Container(
+        ptg.Label("[bold]ANSI Sequences[/]"),
+        "",
+        ptg.Label("SGR:"),
+        sgr_box,
+        "",
+        ptg.Label("Colors:"),
+        colors_box,
+        "",
+        ptg.Label("256-color:"),
+        c256_box,
+        "",
+        ptg.Label("24-bit RGB:"),
+        rgb_box,
+        static_width=column_width,
+    )
+
+    middle = ptg.Container(
+        ptg.Label("[bold]Width & Graphemes[/]"),
+        "",
+        ptg.Label("Word wrap:"),
+        wrap_box,
+        "",
+        ptg.Label("CJK (2-cell):"),
+        cjk_box,
+        "",
+        ptg.Label("Family ZWJ:"),
+        family_box,
+        "",
+        ptg.Label("Flag:"),
+        flag_box,
+        static_width=column_width,
+    )
+
+    right = ptg.Container(
+        ptg.Label("[bold]Grapheme Clusters[/]"),
+        "",
+        ptg.Label("Combining:"),
+        combine_box,
+        "",
+        ptg.Label("Skin tone:"),
+        skin_box,
+        "",
+        ptg.Label("VS-16 heart:"),
+        heart_box,
+        "",
+        ptg.Label("Woman tech:"),
+        tech_box,
+        static_width=column_width,
+    )
+
+    far_right = ptg.Container(
+        ptg.Label("[bold]Long Text[/]"),
+        "",
+        ptg.Label("Lorem ipsum:"),
+        lorem_box,
+        "",
+        ptg.Label("RGB gradient:"),
+        choochoo_box,
+        static_width=column_width,
+    )
+
+    column_containers.extend([left, middle, right, far_right])
+
+    width_label = ptg.Label(f"[dim]Width: {current_width}  |  ←/→ adjust  |  Ctrl+C exit[/]")
+
+    main_window = ptg.Window(
+        ptg.Label("[bold]break_line() Demo[/]"),
+        "",
+        ptg.Splitter(left, middle, right, far_right),
+        "",
+        width_label,
+        width=113,
+    )
+    manager.add(main_window)
+    manager.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = """\
 license = {text = "MIT"}
 
 requires-python = ">=3.8"
-dependencies = ["wcwidth", "typing_extensions"]
+dependencies = ["wcwidth>=0.5", "typing_extensions"]
 
 keywords = [
     "terminal",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,25 +2,28 @@ from pytermgui import break_line, real_length, tim
 
 
 def test_break_plain():
+    # wcwidth.wrap breaks at word boundaries and trims trailing spaces
     text = "123 12345 1234"
     broken = break_line(text, 3)
-    assert list(broken) == ["123", " 12", "345", " 12", "34"]
+    assert list(broken) == ["123", "123", "45", "123", "4"]
 
 
 def test_break_fancy():
+    # wcwidth.wrap breaks at word boundaries; ANSI codes propagate across lines
     text = tim.parse(
         "[141 bold]Hello there[/ italic ansi-blue] whats up[ansi-cyan bold]?"
     )
     broken = break_line(text, 3)
 
+    # wcwidth uses combined SGR params (e.g., \x1b[1;38;5;141m)
     assert list(broken) == [
         "\x1b[38;5;141m\x1b[1mHel\x1b[0m",
-        "\x1b[38;5;141m\x1b[1mlo \x1b[0m",
-        "\x1b[38;5;141m\x1b[1mthe\x1b[0m",
-        "\x1b[38;5;141m\x1b[1mre\x1b[0m\x1b[3m\x1b[38;5;4m \x1b[0m",
-        "\x1b[0m\x1b[3m\x1b[38;5;4mwha\x1b[0m",
-        "\x1b[0m\x1b[3m\x1b[38;5;4mts \x1b[0m",
-        "\x1b[0m\x1b[3m\x1b[38;5;4mup\x1b[38;5;6m\x1b[1m?\x1b[0m",
+        "\x1b[1;38;5;141mlo\x1b[0m",
+        "\x1b[1;38;5;141mthe\x1b[0m",
+        "\x1b[1;38;5;141mre\x1b[0m\x1b[3m\x1b[38;5;4m\x1b[0m",
+        "\x1b[3;38;5;4mwha\x1b[0m",
+        "\x1b[3;38;5;4mts\x1b[0m",
+        "\x1b[3;38;5;4mup\x1b[38;5;6m\x1b[1m?\x1b[0m",
     ]
 
 

--- a/tests/test_wcwidth_integration.py
+++ b/tests/test_wcwidth_integration.py
@@ -1,0 +1,73 @@
+"""Tests for wcwidth 0.5.0+ integration."""
+import re
+
+import pytest
+
+from pytermgui import break_line, real_length
+
+FLAG_US = '\U0001F1FA\U0001F1F8'
+FAMILY_ZWJ = '\U0001F468\u200D\U0001F469\u200D\U0001F467'
+WAVE_SKIN = '\U0001F44B\U0001F3FB'
+CJK = '\u4e2d\u6587\u5b57\u7b26'
+
+# OSC 8 hyperlink format: \x1b]8;;URL\x1b\\TEXT\x1b]8;;\x1b\\
+LINK_OPEN = '\x1b]8;;http://example.com\x1b\\'
+LINK_CLOSE = '\x1b]8;;\x1b\\'
+
+@pytest.mark.parametrize(('text', 'expected'), [
+    ('hello', 5),
+    ('\u4e2d\u6587', 4),
+    ('cafe\u0301', 4),
+    (FLAG_US, 2),
+    (FAMILY_ZWJ, 2),
+    ('\x1b[31mred\x1b[0m', 3),
+], ids=['ascii', 'cjk', 'combining', 'flag', 'zwj', 'sgr'])
+def test_width(text, expected):
+    assert real_length(text) == expected
+
+
+@pytest.mark.parametrize(('text', 'limit', 'expected'), [
+    (CJK, 4, ['\u4e2d\u6587', '\u5b57\u7b26']),
+    ('A\u5973B', 3, ['A\u5973', 'B']),
+], ids=['cjk', 'mixed'])
+def test_wide_char_breaking(text, limit, expected):
+    assert list(break_line(text, limit)) == expected
+
+
+@pytest.mark.parametrize('grapheme', [
+    FLAG_US,
+    FAMILY_ZWJ,
+    WAVE_SKIN,
+], ids=['flag', 'family', 'wave_skin'])
+def test_grapheme_not_split(grapheme):
+    broken = list(break_line(f'Hi{grapheme}!', 3))
+    for line in broken:
+        if grapheme[0] in line:
+            assert grapheme in line
+
+
+def test_hyperlink_sequences_preserved():
+    link = f'{LINK_OPEN}Click here{LINK_CLOSE}'
+    broken = list(break_line(f'Go {link} now', 5))
+    # a nicety in wcwidth -- it will artificially add an 'id' parameter when missing, and,
+    # correctly split a hyperlink across boundaries -- in a well-conforming terminal, the
+    # hyperlink text should correctly share onHover effect.
+    osc8_pattern = re.compile(
+        r'\x1b\]8;[^;]*;http://example\.com\x1b\\(.+)\x1b\]8;;\x1b\\'
+    )
+    assert broken[0] == 'Go'
+    match1 = osc8_pattern.fullmatch(broken[1])
+    assert match1 and match1.group(1) == 'Click'
+    match2 = osc8_pattern.fullmatch(broken[2])
+    assert match2 and match2.group(1) == 'here'
+    assert broken[3] == 'now'
+
+
+def test_hyperlink_width_is_text_only():
+    link = f'{LINK_OPEN}Hi{LINK_CLOSE}'
+    assert real_length(link) == 2
+
+
+def test_cjk_wrap_matches_wcwidth():
+    from wcwidth import wrap as wcwidth_wrap
+    assert list(break_line(CJK, 4)) == wcwidth_wrap(CJK, 4)


### PR DESCRIPTION
**Problem**: ``break_line()`` has basic line-wrapping behavior, it does not have "word" wrapping behavior like standard python, only character-by-character, CJK is mis-measured, or sequences like the canadian flag get broken in half into blue "C" and "A" letters, or emojis (eg, "My family") get broken from their zero-width-joiner and variation sequences, expanding as they break.

See attached video, ``examples/wcwidth_demo.py`` with arrow keys, first half on 'master' branch, second half with this PR:

https://github.com/user-attachments/assets/554c27f4-2958-43d3-8922-a82f20ee61d3

**Solution** Simplify ``break_line()`` to use [wcwidth.wrap()](https://wcwidth.readthedocs.io/en/latest/api.html#wcwidth.wrap) for word-boundary breaking, now it follows python ``textwrap.wrap()`` behavior but with all of the grapheme clustering, emoji, flags, ZWJ sequences, and SGR attribute support.

A change deep in ``get_lines()`` is also necessary due to re-use of loop variable ``target_width`` outside of loop combined with zip_longest made illegal layout values -- we now calculate the maximum height with varying widths in mind. This bugfix is only needed with this branch, it does not fix any existing bug that I know of. 


